### PR TITLE
Add enabling of pam_sss

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -115,3 +115,7 @@ sssd_build_threads: 2
 # The default build options are stored in `vars/{{ ansible_os_family }}.yml`
 # Type: List
 sssd_build_options: "{{ sssd_default_build_options }}"
+
+# This will enable pam_sss
+# Type: Bool
+enable_pam_sss: true

--- a/tasks/sssd-config.yml
+++ b/tasks/sssd-config.yml
@@ -13,6 +13,23 @@
         (not sssd_from_sources) and
         (ansible_os_family == "RedHat")
 
+- name: Install authconfig
+  package:
+    name: authconfig
+    state: present
+  when: enable_pam_sss and ansible_os_family == 'RedHat'
+
+- name: Test if pam_sss is enabled
+  command: grep -R pam_sss /etc/pam.d
+  failed_when: false
+  changed_when: false
+  register: pam_sss_disabled
+  when: enable_pam_sss
+
+- name: Enable pam_sss
+  command: "{{ enable_pam_sss_command }}"
+  when: enable_pam_sss and pam_sss_disabled.rc != 0
+
 - name: Configure SSSD service (from config)
   template:
     dest: /etc/sssd/sssd.conf

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -254,3 +254,7 @@ sssd_postinst_set_permissions:
 # SSH Service name
 # Type: Str
 sssd_ssh_service_name: ssh
+
+# Command to enable pam_sss
+# Type: Str
+enable_pam_sss_command: pam-auth-update --enable sss

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -219,3 +219,7 @@ sssd_postinst_set_permissions:
 # SSH Service name
 # Type: Str
 sssd_ssh_service_name: sshd
+
+# Command to enable pam_sss
+# Type: Str
+enable_pam_sss_command: authconfig --enablesssd --enablesssdauth --updateall


### PR DESCRIPTION
On RHEL pam_sss is not enable by default when installing sssd.